### PR TITLE
fix: remove lodash, use es2015

### DIFF
--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -1,6 +1,16 @@
 "use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-var _ = require("lodash");
 require("reflect-metadata");
 /**
  * Decorator JsonProperty
@@ -38,10 +48,9 @@ function deserialize(json, type) {
         instanceMap = Reflect.getMetadata('api:map:' + instanceName, instance);
         if (baseClassName) {
             var baseClassMap = Reflect.getMetadata('api:map:' + baseClassName, instance);
-            instanceMap = _.merge(instanceMap, baseClassMap);
+            instanceMap = __assign({}, instanceMap, baseClassMap);
         }
-        var keys = _.keys(instanceMap);
-        _.forEach(keys, function (key) {
+        Object.keys(instanceMap).forEach(function (key) {
             if (json[instanceMap[key].name] !== undefined) {
                 instance[key] = convertDataToProperty(instance, key, instanceMap[key], json[instanceMap[key].name]);
             }
@@ -63,7 +72,7 @@ function serialize(instance, removeUndefined) {
         instanceMap = Reflect.getMetadata('api:map:' + instanceName, instance);
         if (baseClassName !== undefined) {
             var baseClassMap = Reflect.getMetadata('api:map:' + baseClassName, instance);
-            instanceMap = _.merge(instanceMap, baseClassMap);
+            instanceMap = __assign({}, instanceMap, baseClassMap);
         }
         Object.keys(instanceMap).forEach(function (key) {
             var data = convertPropertyToData(instance, key, instanceMap[key], removeUndefined);

--- a/package.json
+++ b/package.json
@@ -28,11 +28,9 @@
         "metadata"
     ],
     "dependencies": {
-        "lodash": "^4.17.11",
         "reflect-metadata": "^0.1.13"
     },
     "devDependencies": {
-        "@types/lodash": "^4.14.120",
         "@types/mocha": "^5.2.5",
         "@types/node": "^10.12.23",
         "chai": "^4.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import 'reflect-metadata';
 
 /**
@@ -43,11 +42,10 @@ export function deserialize(json: any, type: any): any {
 
         if (baseClassName) {
             const baseClassMap: { [id: string]: any; } = Reflect.getMetadata('api:map:' + baseClassName, instance);
-            instanceMap = _.merge(instanceMap, baseClassMap);
+            instanceMap = { ...instanceMap, ...baseClassMap };
         }
 
-        const keys: Array<string> = _.keys(instanceMap);
-        _.forEach(keys, (key: string) => {
+        Object.keys(instanceMap).forEach((key: string) => {
             if (json[instanceMap[key].name] !== undefined) {
                 instance[key] = convertDataToProperty(instance, key, instanceMap[key], json[instanceMap[key].name]);
             }
@@ -72,7 +70,7 @@ export function serialize(instance: any, removeUndefined: boolean = true): any {
 
         if (baseClassName !== undefined) {
             const baseClassMap: { [id: string]: any; } = Reflect.getMetadata('api:map:' + baseClassName, instance);
-            instanceMap = _.merge(instanceMap, baseClassMap);
+            instanceMap = { ...instanceMap, ...baseClassMap };
         }
 
         Object.keys(instanceMap).forEach((key: string) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
         "typeRoots": [
             "node_modules/@types"
         ],
+        "types": ["node", "mocha"],
         "lib": [
             "es2015",
             "dom"


### PR DESCRIPTION
After trying this library I found it pretty useful but produced too large bundle size around 113kb. I found it depends on lodash and I think we can remove it so I submit the PR for this reason. 

So, basically. this PR change from this.

![Screenshot from 2019-03-29 00-39-30](https://user-images.githubusercontent.com/3924130/55180798-e8073a00-51bc-11e9-80fc-ee6ecd229f28.png)

to this.

![Screenshot from 2019-03-29 00-34-41](https://user-images.githubusercontent.com/3924130/55180813-efc6de80-51bc-11e9-803f-6518c50b8a44.png)

Hope you like it, let me know if you need further changes.

Regards,