### PR TITLE
Fix getParamNames()

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ export enum Status {
 export class Employee {
 
     /**
-     * The employee's id
+     * The employee's id (PK)
      */
     @JsonProperty()
     public id: number;
@@ -121,7 +121,7 @@ export class Employee {
     public email: string;
 
     public constructor(
-        // This comment will throw an error
+        // This comment works
         @JsonProperty() public name: string,
         @JsonProperty() public gender: Gender,
         /** This comment works */

--- a/examples/models/employee.ts
+++ b/examples/models/employee.ts
@@ -16,9 +16,10 @@ export class Employee {
     public email: string;
 
     public constructor(
+        // This comment works
         @JsonProperty() public name: string,
         @JsonProperty() public gender: Gender,
-        /** The birth date of the employee */
+        /** The birth date of the employee (readonly) */
         @JsonProperty() public readonly birthDate: Date
     ) { }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "typescript-json-serializer",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "description": "Typescript library to serialize classes into json and deserialize json into classes.",
     "main": "index.js",
     "types": "index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,13 +12,23 @@ const designParamtypes: string = 'design:paramtypes';
  * Function to find the name of function parameters
  */
 function getParamNames(ctor: object): Array<string> {
-    // Get params from constructor string
-    let params: string = ctor.toString().match(/function\s.*?\(([^)]*)\)/)[1];
-
-    // Remove jsDoc from params
-    params = params.replace(/\/\*.*\*\//g, '');
-
-    return params.replace(/\s/g, '').split(',');
+    return (
+        [ctor.toString()]
+            // 1. Remove all kind of comments
+            .map((_: string) => _.replace(/(\/\*[\s\S]*?\*\/|([^:]|^)\/\/.*$)/gm, ''))
+            // 2. Parse as a function declaration
+            .map((_: string) => _.match(/function\s.*?\(((?:)|([^)]*))\)/))
+            // 3. Get the parsed string
+            .map((matches?: RegExpMatchArray) => (matches && matches[1]) || '')
+            // 4. Remove all whitespaces
+            .map((_: string) => _.replace(/\s/g, ''))
+            // 5. Split by comma
+            .map((_: string) => _.split(','))
+            // 6. Collect parameter names to array
+            .reduce((acc: Array<string>, params: Array<string>) => acc.concat(params))
+            // 7. Filter out blanks
+            .filter((_: string) => Boolean(_))
+    );
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ function getParamNames(ctor: object): Array<string> {
     return (
         [ctor.toString()]
             // 1. Remove all kind of comments
-            .map((_: string) => _.replace(/(\/\*[\s\S]*?\*\/|([^:]|^)\/\/.*$)/gm, ''))
+            .map((_: string) => _.replace(/(\/\*[\s\S]*?\*\/|\/\/.*$)/gm, ''))
             // 2. Parse as a function declaration
             .map((_: string) => _.match(/function\s.*?\(((?:)|([^)]*))\)/))
             // 3. Get the parsed string


### PR DESCRIPTION
Hi.

While you already fixed it, I found it wouldn't work if block comment contains closing parenthesis `)` in it.

Fortunately, I just came to know how `getParamNames()` works, and found the way to solve the issue.

So, please accept this fix.

Thank you.


## References

- [Remove inline/block comments from code files](https://www.regextester.com/94246)
