### PR TITLE
Add returning type inference on function deserialize()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export function Serializable(baseClassName?: string): Function {
 /**
  * Function to deserialize json into a class
  */
-export function deserialize(json: any, type: any): any {
+export function deserialize<T>(json: any, type: new (..._: Array<any>) => T): T {
     const instance: any = new type();
     const instanceName: string = instance.constructor.name;
     const baseClassName: string = Reflect.getMetadata(apiMapSerializable, type);


### PR DESCRIPTION
I think this would make it more convenient to use.

## AS-IS

`deserialize(..., T)` has been returning `any`

## TO-BE

`deserialize(..., T)` should return `T`
