### PR TITLE
Parse parameter name only after encountering a dot

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ function getParamNames(ctor: object): Array<string> {
     const withoutComments: string = ctor.toString().replace(/(\/\*[\s\S]*?\*\/|\/\/.*$)/gm, '');
 
     // Parse function body
-    const parameterPattern: RegExp = /(?:this.)([^\s=;]+)\s*=/gm;
+    const parameterPattern: RegExp = /(?:this.*\.)([^\s=;]+)\s*=/gm;
     const paramNames: Array<string> = [];
     let match: RegExpExecArray;
 


### PR DESCRIPTION
Hi, I'm using this package with Babel and it seems to do a funny thing when there are multiple classes in a single file and these classes extend from another class:

```typescript
abstract class TimeSpecification {
    abstract type: string;
}

class Scheduled extends TimeSpecification {
    public constructor(
        scheduledAt: Date,
    ) {
        this.scheduledAt = scheduledAt;
    }
}

class Estimate extends TimeSpecification {
    public constructor(
        estimatedBetween: [Date, Date],
    ) {
        this.estimatedBetween = estimatedBetween;
    }
}
```

Produces this code ([repl](https://babeljs.io/repl#?browsers=%3E%202%25%2C%20not%20dead%2C%20not%20op_mini%20all&build=&builtIns=false&spec=false&loose=false&code_lz=IYIwzgLgTsDGEAJYBthjAgKgSwLYFMBlAB31mwDNtZgJsB7AOwQG8AoBThUSGeBCAE9SALgS9sjAOYBuNgF82bFGgyFYAC3wATAK7IdCfAA8I-Rtow4CJMpWq0GzdlwTFdIZNSRNeu-PRQABQcrlxgmjr6OgCCEGIAIrT4ADShnACUrOlhEBrYYAB0EVp6BtpxCAC84pFlsRByroqKyqjoCACikHjJRqbmllh4RKTkVDR0TNmu7p7esL7Q_hCBIWFc-D24ydoAQvgQAO745mIA2klmKQhX-AC6aa5ZLhsC-UVbdDtm-4cn5mqRm2uwOx1OjCaXBaQA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=true&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Ctypescript&prettier=false&targets=&version=7.8.4&externalPlugins=)):

```javascript
var TimeSpecification = function TimeSpecification() {
  _classCallCheck(this, TimeSpecification);
};

var Scheduled =
/*#__PURE__*/
function (_TimeSpecification) {
  _inherits(Scheduled, _TimeSpecification);

  function Scheduled(scheduledAt) {
    var _this;

    _classCallCheck(this, Scheduled);

    _this.scheduledAt = scheduledAt;
    return _possibleConstructorReturn(_this);
  }

  return Scheduled;
}(TimeSpecification);

var Estimate =
/*#__PURE__*/
function (_TimeSpecification2) {
  _inherits(Estimate, _TimeSpecification2);

  function Estimate(estimatedBetween) {
    var _this2;

    _classCallCheck(this, Estimate);

    _this2.estimatedBetween = estimatedBetween;
    return _possibleConstructorReturn(_this2);
  }

  return Estimate;
}(TimeSpecification);
```

The problem is that Babel generates a file-scoped unique identifier in place of `this`, by adding an incremental number. This confuses the regex in `getParamNames` so that, in this case, it returns `.estimatedBetween` with a leading dot.

As there seems to be only little incentive to change this in Babel (babel/babel#6045), I was able to fix it in this library by changing the regex so that it takes the parameter name only after it encounters a dot. (I believe the dot was meant to be escaped in the original regex anyway?)

It works, but I'm not sure about it – the regex feels too lenient now and I'm afraid it might mistake non-parameters for parameter names in various edge cases. What are your thoughts?