### PR TITLE
Fixing null value problem with enum

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -324,7 +324,7 @@ function convertPropertyToData(
 ): any {
     const property: any = instance[key];
     const type: any = Reflect.getMetadata(designType, instance, key);
-    const isArray = type.name.toLocaleLowerCase() === Type.Array;
+    var isArray = type.name ? type.name.toLocaleLowerCase() === Type.Array : false;
     const predicate: Function = metadata['predicate'];
     const propertyType: any = metadata['type'] || type;
     const isSerializableProperty = isSerializable(propertyType);
@@ -385,7 +385,7 @@ function convertDataToProperty(instance: Function, key: string, metadata: Metada
     }
 
     const type: any = Reflect.getMetadata(designType, instance, key);
-    const isArray = type.name.toLowerCase() === Type.Array;
+    var isArray = type.name ? type.name.toLowerCase() === Type.Array : false;
     const isDictionary = metadata['isDictionary'];
     const predicate: Function = metadata['predicate'];
     const onDeserialize: Function = metadata['onDeserialize'];
@@ -509,6 +509,10 @@ function getJsonPropertyValue(key: string, args: Args): Metadata {
  * @returns {any} The casted data
  */
 function castSimpleData(type: string, data: any): any {
+
+    if (type === undefined)
+        return data;
+
     type = type.toLowerCase();
 
     if ((typeof data).toLowerCase() === type) {


### PR DESCRIPTION
Fixing null value for enums ( call to Reflect.getMetadata(designType, instance, key) returns a null value for enums).
An exampls of the object I try to deserialize is atached to the PR. The problem occures for the DataLoggingState field.

Ts type :
export enum ELoggingState {
Stopped = 0,
Paused = 1,
Running = 2,
}
[sample.zip](https://github.com/GillianPerard/typescript-json-serializer/files/5494522/sample.zip)

