### PR TITLE
fix: 🐛 export isNullish

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,4 @@ export {
 } from './json-serializer-options';
 export { JsonObject, JsonObjectMetadata } from './json-object';
 export { JsonProperty } from './json-property';
+export { isNullish } from './helpers'


### PR DESCRIPTION
Serialization returns the generic type or Nullish.  This allows for type
checking the return object without a deep import.

✅ Closes: #176


This fixes just this one export.   If you have other designs here - you're welcome to trash this PR and do it.  :) 