### PR TITLE
feat: add Set & Map support

### DIFF
--- a/src/json-serializer.ts
+++ b/src/json-serializer.ts
@@ -297,7 +297,10 @@ export class JsonSerializer {
         }
 
         const type = Reflection.getType(instance, propertyKey);
-        const isArrayProperty = type?.name?.toLowerCase() === 'array';
+        const typeName = type?.name?.toLowerCase();
+        const isArrayProperty = typeName === 'array';
+        const isSetProperty = typeName === 'set';
+        const isMapProperty = typeName === 'map';
         let propertyType = metadata.type || type;
 
         if (metadata.beforeDeserialize) {
@@ -307,10 +310,16 @@ export class JsonSerializer {
         let property: any;
         const predicate = metadata.predicate;
 
-        if (metadata.isDictionary) {
+        if (metadata.isDictionary || isMapProperty) {
             property = this.deserializeDictionary(dataSource, propertyType, predicate);
-        } else if (isArrayProperty) {
+            if (isMapProperty) {
+                property = new Map(Object.entries(property));
+            }
+        } else if (isArrayProperty || isSetProperty) {
             property = this.deserializeArray(dataSource, propertyType, predicate);
+            if (isSetProperty) {
+                property = new Set(property);
+            }
         } else if (
             (!isJsonObject(propertyType) && !predicate) ||
             (predicate && !predicate(dataSource, obj))
@@ -550,17 +559,36 @@ export class JsonSerializer {
     private serializeProperty(instance: object, key: string, metadata: JsonPropertyMetadata): any {
         const property = instance[key];
         const type = Reflection.getType(instance, key);
-        const isArrayProperty = type?.name?.toLocaleLowerCase() === 'array';
+        const typeName = type?.name?.toLowerCase();
+        const isArrayProperty = typeName === 'array';
+        const isSetProperty = typeName === 'set';
+        const isMapProperty = typeName === 'map';
         const predicate = metadata.predicate;
         const propertyType = metadata.type || type;
         const isJsonObjectProperty = isJsonObject(propertyType);
 
         if (property && (isJsonObjectProperty || predicate)) {
-            if (isArrayProperty) {
-                return this.serializeObjectArray(property);
+            if (isArrayProperty || isSetProperty) {
+                const array = isSetProperty ? Array.from(property) : property;
+                return this.serializeObjectArray(array);
             }
 
-            if (metadata.isDictionary) {
+            if (metadata.isDictionary || isMapProperty) {
+                if (isMapProperty) {
+                    const obj = {};
+                    property.forEach((value, mapKey) => {
+                        if (!isString(mapKey)) {
+                            this.error(
+                                `Fail to serialize: type '${typeof mapKey}' is not assignable to type 'string'.\nReceived: ${JSON.stringify(
+                                    mapKey
+                                )}.`
+                            );
+                            return undefined;
+                        }
+                        obj[mapKey] = value;
+                    });
+                    return this.serializeDictionary(obj);
+                }
                 return this.serializeDictionary(property);
             }
 


### PR DESCRIPTION
Hi,

Thank you for this efficient library. I am dealing with data with [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set). I think it is a good idea to support these common collections in the library, instead of adding many `beforeSerialize` and `afterDeserialize` functions and `isDictionary` marks.

What do you think about this feature? I have implemented the `Map` and `Set` support and it works well in my simple test. I can also add some test examples if the feature is ok to merge.