### PR TITLE
feat: add auto prediction of child class

### DIFF
--- a/spec/auto-predicate.spec.ts
+++ b/spec/auto-predicate.spec.ts
@@ -1,0 +1,111 @@
+// eslint-disable-next-line max-classes-per-file
+import { JsonObject, JsonProperty, JsonSerializer } from '../src';
+
+@JsonObject({ autoPredicate: true })
+abstract class Base {
+    @JsonProperty() property0: string;
+}
+
+@JsonObject()
+class ChildA extends Base {
+    @JsonProperty() property1: string;
+}
+
+@JsonObject()
+class ChildB extends Base {
+    @JsonProperty() property2: string;
+}
+
+@JsonObject()
+class Outer {
+    @JsonProperty()
+    property: Base;
+}
+
+@JsonObject()
+class OuterArray {
+    @JsonProperty({ type: Base })
+    property: Array<Base>;
+}
+
+describe('auto-predicate', () => {
+    it('serialize and deserialize', () => {
+        const jsonSerializer = new JsonSerializer();
+        const childA = new ChildA();
+        childA.property0 = 'property0';
+        childA.property1 = 'property1';
+        const childB = new ChildB();
+        childB.property0 = 'property0';
+        childB.property2 = 'property2';
+
+        const outer = new Outer();
+        outer.property = childA;
+
+        const json = jsonSerializer.serialize(outer);
+        expect(json).toEqual({
+            property: {
+                __class__: 'ChildA',
+                property0: 'property0',
+                property1: 'property1'
+            }
+        });
+
+        if (json) {
+            const deserialized = jsonSerializer.deserialize(json, Outer);
+            expect(deserialized).toEqual(outer);
+        }
+
+        const outer2 = new Outer();
+        outer2.property = childB;
+        const json2 = jsonSerializer.serialize(outer2);
+        expect(json2).toEqual({
+            property: {
+                __class__: 'ChildB',
+                property0: 'property0',
+                property2: 'property2'
+            }
+        });
+
+        if (json2) {
+            const deserialized2 = jsonSerializer.deserialize(json2, Outer);
+            expect(deserialized2).toEqual(outer2);
+        }
+    });
+});
+
+describe('child-class-array', () => {
+    it('should serialize', () => {
+        const jsonSerializer = new JsonSerializer();
+        const childA = new ChildA();
+        childA.property0 = 'property0';
+        childA.property1 = 'property1';
+        const childB = new ChildB();
+        childB.property0 = 'property0';
+        childB.property2 = 'property2';
+
+        const outerArray = new OuterArray();
+        outerArray.property = [childA, childB];
+
+        const json = jsonSerializer.serialize(outerArray);
+
+        expect(json).toEqual({
+            property: [
+                {
+                    __class__: 'ChildA',
+                    property0: 'property0',
+                    property1: 'property1'
+                },
+                {
+                    __class__: 'ChildB',
+                    property0: 'property0',
+                    property2: 'property2'
+                }
+            ]
+        });
+
+        if (json) {
+            const deserialized = jsonSerializer.deserialize(json, OuterArray);
+            expect(deserialized).toEqual(outerArray);
+        }
+    });
+});

--- a/spec/reflection.spec.ts
+++ b/spec/reflection.spec.ts
@@ -33,9 +33,9 @@ describe('Reflection', () => {
         expect(spy).not.toHaveBeenCalled();
     });
 
-    it('setJsonObject should not define json object if there is no target', () => {
+    it('setJsonObjectMetadata should not define json object if there is no target', () => {
         const spy = jest.spyOn(Reflect, 'defineMetadata');
-        Reflection.setJsonObject({ baseClassNames: [] }, unknownTarget);
+        Reflection.setJsonObjectMetadata({ baseClassNames: [] }, unknownTarget);
         expect(spy).not.toHaveBeenCalled();
     });
 

--- a/src/json-object.ts
+++ b/src/json-object.ts
@@ -2,14 +2,36 @@ import { Reflection } from './reflection';
 
 export interface JsonObjectMetadata {
     baseClassNames: Array<string>;
+    autoPredicate?: boolean;
 }
 
 const getBaseClassNames = (target: Object): Array<string> => {
-    const baseClass = Reflection.getBaseClass(target);
+    const baseClass = Reflection.getBaseClass(target) as { name: string };
     return baseClass && baseClass.name ? [...getBaseClassNames(baseClass), baseClass.name] : [];
 };
 
-export const JsonObject = (): Function => (target: Object) => {
-    const baseClassNames = getBaseClassNames(target);
-    Reflection.setJsonObject({ baseClassNames }, target);
+export const getBaseClasses = (target: Object): Array<Function> => {
+    const baseClass = Reflection.getBaseClass(target);
+    return baseClass && baseClass.name ? [...getBaseClasses(baseClass), baseClass] : [];
 };
+
+interface JsonObjectOptions {
+    autoPredicate?: boolean;
+}
+
+export const JsonObject =
+    (options?: JsonObjectOptions): Function =>
+    (target: Object) => {
+        const baseClassNames = getBaseClassNames(target);
+        Reflection.setJsonObjectMetadata(
+            { baseClassNames, autoPredicate: options ? options.autoPredicate : undefined },
+            target
+        );
+
+        const baseClasses = getBaseClasses(target);
+        baseClasses.forEach(baseClass => {
+            const children = Reflection.getJsonObjectChildClass(baseClass);
+            const newChildren = children ? children.concat([target]) : [target];
+            Reflection.setJsonObjectChildClass(newChildren, baseClass);
+        });
+    };

--- a/src/reflection.ts
+++ b/src/reflection.ts
@@ -7,9 +7,10 @@ export class Reflection {
     static apiMapJsonObject = `${Reflection.apiMap}jsonObject`;
     static designType = 'design:type';
     static designParamTypes = 'design:paramtypes';
+    static apiMapJsonObjectChildClass = `${Reflection.apiMap}jsonObjectChildClass:`;
 
-    static getBaseClass(target: object): { name: string } | undefined {
-        return target ? (Reflect.getPrototypeOf(target) as { name: string }) : undefined;
+    static getBaseClass(target: object): Function | undefined {
+        return target ? (Reflect.getPrototypeOf(target) as Function) : undefined;
     }
 
     static getJsonPropertiesMetadata(
@@ -38,6 +39,12 @@ export class Reflection {
         return target ? Reflect.getMetadata(Reflection.designType, target, key) : undefined;
     }
 
+    static getJsonObjectChildClass(target: Function): any | undefined {
+        return target
+            ? Reflect.getMetadata(`${Reflection.apiMapJsonObjectChildClass}${target.name}`, target)
+            : undefined;
+    }
+
     static isJsonObject(type: object): boolean {
         return type ? Reflect.hasOwnMetadata(Reflection.apiMapJsonObject, type) : false;
     }
@@ -51,7 +58,7 @@ export class Reflection {
         Reflect.defineMetadata(key, value, target);
     }
 
-    static setJsonObject(value: JsonObjectMetadata, target: object): void {
+    static setJsonObjectMetadata(value: JsonObjectMetadata, target: object): void {
         if (!target) {
             return;
         }
@@ -65,5 +72,17 @@ export class Reflection {
         }
 
         Reflect.defineMetadata(Reflection.designType, type, target, key);
+    }
+
+    static setJsonObjectChildClass(value: object, target: Function): void {
+        if (!target) {
+            return;
+        }
+
+        Reflect.defineMetadata(
+            `${Reflection.apiMapJsonObjectChildClass}${target.name}`,
+            value,
+            target
+        );
     }
 }


### PR DESCRIPTION
When dealing with class inheritance in typescript, it is a good idea to store the class name as a field (e.g. `__class__`) in the json object when serializing and inspect this field when deserializing it. We can add a `JsonObject` option named `autoPredicate` in the base class to let the user decide whether to use this feature. You can see `auto-predicate.spec.ts` for its usage.

I have implemented a prototype of this feature, it does not have any side effects on existing functions. I hope that you add this function by merging this PR or implementing this yourself referring to my code. Thanks~

BTW, I have also renamed `setJsonObject` to `setJsonObjectMetadata` to match the `getJsonObjectMetadata` function.